### PR TITLE
Korjaa kirjoitusvirhe ja determinantin sulkeet

### DIFF
--- a/luku23.tex
+++ b/luku23.tex
@@ -342,46 +342,46 @@ ja joka toinen negatiivisena.
 \begin{samepage}
 Esimerkiksi
 \[
-\det(
+\det\left(
  \begin{bmatrix}
   3 & 4 \\
   1 & 6 \\
  \end{bmatrix}
-) = 3 \cdot 6 - 4 \cdot 1 = 14 
+\right) = 3 \cdot 6 - 4 \cdot 1 = 14 
 \]
 \end{samepage}
 
 ja
 
 \[
-\det(
+\det\left(
  \begin{bmatrix}
   2 & 4 & 3 \\
   5 & 1 & 6 \\
   7 & 2 & 4 \\
  \end{bmatrix}
-) = 
+\right) = 
 2 \cdot
-\det(
+\det\left(
  \begin{bmatrix}
   1 & 6 \\
   2 & 4 \\
  \end{bmatrix}
-)
+\right)
 -4 \cdot
-\det(
+\det\left(
  \begin{bmatrix}
   5 & 6 \\
   7 & 4 \\
  \end{bmatrix}
-)
+\right)
 +3 \cdot
-\det(
+\det\left(
  \begin{bmatrix}
   5 & 1 \\
   7 & 2 \\
  \end{bmatrix}
-) = 81.
+\right) = 81.
 \]
 
 \index{kxxnteismatriisi@käänteismatriisi}
@@ -759,7 +759,7 @@ Tämä polku on $2 \rightarrow 1 \rightarrow 4 \rightarrow 2 \rightarrow 5$.
 \index{virittxvx puu@virittävä puu}
 
 \key{Kirchhoffin lause} laskee
-verkon virittävän puiden määrän
+verkon virittävien puiden määrän
 verkosta muodostetun matriisin determinantin avulla.
 Esimerkiksi verkolla
 \begin{center}
@@ -831,13 +831,13 @@ jokin rivi ja jokin sarake.
 Esimerkiksi jos poistamme ylimmän rivin ja
 vasemman sarakkeen, tuloksena on
 
-\[ \det(
+\[ \det\left(
 \begin{bmatrix}
   1 & 0 & 0 \\
   0 & 2 & -1 \\
   0 & -1 & 2 \\
  \end{bmatrix}
-) =3.\]
+\right) =3.\]
 Determinantista tulee aina sama riippumatta siitä,
 mikä rivi ja sarake matriisista $L$ poistetaan.
 
@@ -845,14 +845,14 @@ Huomaa, että Kirchhoffin lauseen erikoistapauksena on
 luvun 22.5 Cayleyn kaava, koska
 täydellisessä $n$ solmun verkossa
 
-\[ \det(
+\[ \det\left(
 \begin{bmatrix}
   n-1 & -1 & \cdots & -1 \\
   -1 & n-1 & \cdots & -1 \\
   \vdots & \vdots & \ddots & \vdots \\
   -1 & -1 & \cdots & n-1 \\
  \end{bmatrix}
-) =n^{n-2}.\]
+\right) =n^{n-2}.\]
 
 
 


### PR DESCRIPTION
Kirchhoffin lause -kappaleessa: virittävän puiden määrän --> virittävien puiden määrän
Vaihda matriisin determinanttia ottaessa oikean kokoisiin sulkeisiin kaikkialla luvussa 23.